### PR TITLE
Attribute default value Lambda rather than Proc

### DIFF
--- a/lib/diagnostics/sample/result.rb
+++ b/lib/diagnostics/sample/result.rb
@@ -3,15 +3,15 @@ module Diagnostics
     class Result
       include Schema::DataStructure
 
-      attribute :cycles, Integer, default: proc { 0 }
-      attribute :time_milliseconds, Float, default: proc { 0.0 }
-      attribute :time_sum_squares, Float, default: proc { 0.0 }
+      attribute :cycles, Integer, default: -> { 0 }
+      attribute :time_milliseconds, Float, default: -> { 0.0 }
+      attribute :time_sum_squares, Float, default: -> { 0.0 }
 
-      attribute :warmup_cycles, Integer, default: proc { 0 }
-      attribute :warmup_time_milliseconds, Float, default: proc { 0.0 }
-      attribute :warmup_time_sum_squares, Float, default: proc { 0.0 }
+      attribute :warmup_cycles, Integer, default: -> { 0 }
+      attribute :warmup_time_milliseconds, Float, default: -> { 0.0 }
+      attribute :warmup_time_sum_squares, Float, default: -> { 0.0 }
 
-      attribute :gc, Boolean, default: proc { false }
+      attribute :gc, Boolean, default: -> { false }
 
       def cycle(elapsed_time)
         self.time_milliseconds += elapsed_time


### PR DESCRIPTION
Message from community slack:

>  If the default value is defined with proc, and somewhat innocently uses an explicit return to set the value, it would return from the evaluation of the class definition itself, which is a LocalJumpError.
> So, proc is less correct than lambda
> Or the lambda literal (->)
> We're going to update all of our examples to use lambdas instead of procs

Source: [Thu, June 27th](https://eventide-project.slack.com/archives/C1072LL64/p1719447266368679)